### PR TITLE
refine cal.com themed experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,15 +5,15 @@
 - Get instant insights into meetings, event types, and booking trends without a custom backend.
 - Built with Next.js 16, Tailwind CSS v4, and Prisma.
 - Cal.com OAuth 2.0 flow authenticates users via Next.js async cookies and exchanges tokens at `https://api.cal.com/v2/oauth/token`.
-- Landing and dashboard surfaces currently ship with a Halloween theme driven by shared tokens and animations in `app/globals.css`.
+- Landing and dashboard surfaces currently ship with a Cal.com-inspired theme driven by shared tokens and animations in `app/globals.css`.
 
 ## Code Map
 - `app/layout.tsx`: root layout, font loading, metadata, and analytics wiring
 - `.agent/cal-com-openapi-spec.yaml`: Cal.com API v2 OpenAPI excerpt kept in sync with the official docs
 - `.agent/coding-style.md`: shared coding conventions for components, styling, async flows, and quality gates
 - `.agent/react-component-template.md`: starter client component snippet for quick copy/paste usage
-- `modules/landing/Hero.tsx`: seasonal marketing hero with Cal.com OAuth CTA and motion accents
-- `modules/dashboard/App.tsx`: client dashboard shell with Halloween gradients and analytics modules
+- `modules/landing/Hero.tsx`: Cal.com-flavored marketing hero with OAuth CTA and motion accents
+- `modules/dashboard/App.tsx`: client dashboard shell with Cal.com gradients and analytics modules
 - `app/page.tsx`: primary UI; copy lives in the `DESCRIPTION` constant rendered twice to test wrapping
 - `app/dashboard/page.tsx`: server component entry point that renders the dashboard `App`
 - `app/dashboard/loading.tsx`: route-level loading fallback for the dashboard

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Lightweight analytics for Cal.com workspaces. Callytics gives teams instant visi
 ## Features 💡
 - OAuth 2.0 flow for Cal.com accounts with stateful callback handling 🔐
 - Postgres-backed waitlist capture powered by Prisma Accelerate 📨
-- Interactive, Halloween-themed landing hero with shared neon animations and OAuth CTA 🎃
-- Analytics dashboard refreshed with the seasonal palette, motion charts, and dark-mode friendly glows 📈
+- Interactive landing hero styled to mirror Cal.com's product aesthetic and OAuth CTA ⚡️
+- Analytics dashboard refreshed with the Cal.com palette, motion charts, and dark-mode friendly glows 📈
 - Turbopack-enabled Next.js 16 app router with Tailwind CSS v4 styling ⚡️
 
 ## Tech Stack 🛠️

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,74 +4,74 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(0.98 0.02 82);
-  --foreground: oklch(0.26 0.04 40);
-  --card: oklch(0.96 0.02 86);
-  --card-foreground: oklch(0.28 0.04 42);
-  --popover: oklch(0.99 0.01 88);
+  --background: oklch(0.99 0.002 255);
+  --foreground: oklch(0.23 0.02 255);
+  --card: oklch(0.99 0.001 255);
+  --card-foreground: var(--foreground);
+  --popover: oklch(1 0 0);
   --popover-foreground: var(--foreground);
-  --primary: oklch(0.68 0.19 45);
-  --primary-foreground: oklch(0.12 0 0);
-  --secondary: oklch(0.92 0.03 70);
-  --secondary-foreground: oklch(0.32 0.04 42);
-  --muted: oklch(0.92 0.03 70);
-  --muted-foreground: oklch(0.45 0.04 42);
-  --accent: oklch(0.9 0.05 80);
-  --accent-foreground: oklch(0.28 0.04 42);
-  --destructive: oklch(0.63 0.24 27);
-  --destructive-foreground: oklch(0.98 0 0);
-  --border: oklch(0.87 0.02 75);
-  --input: oklch(0.89 0.02 75);
-  --ring: oklch(0.68 0.19 45);
-  --chart-1: oklch(0.68 0.19 45);
-  --chart-2: oklch(0.75 0.15 85);
-  --chart-3: oklch(0.55 0.12 25);
-  --chart-4: oklch(0.82 0.1 95);
-  --chart-5: oklch(0.45 0.08 15);
+  --primary: oklch(0.33 0.03 255);
+  --primary-foreground: oklch(0.99 0.002 255);
+  --secondary: oklch(0.95 0.005 255);
+  --secondary-foreground: var(--foreground);
+  --muted: oklch(0.94 0.004 255);
+  --muted-foreground: oklch(0.45 0.015 255);
+  --accent: oklch(0.75 0.08 230);
+  --accent-foreground: oklch(0.19 0.02 255);
+  --destructive: oklch(0.56 0.16 27);
+  --destructive-foreground: oklch(0.99 0.002 255);
+  --border: oklch(0.91 0.003 255);
+  --input: oklch(0.92 0.003 255);
+  --ring: var(--accent);
+  --chart-1: oklch(0.62 0.09 231);
+  --chart-2: oklch(0.7 0.06 210);
+  --chart-3: oklch(0.55 0.05 260);
+  --chart-4: oklch(0.64 0.06 175);
+  --chart-5: oklch(0.76 0.07 120);
   --radius: 0.75rem;
-  --sidebar: oklch(0.96 0.02 86);
+  --sidebar: oklch(0.98 0.002 255);
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: var(--primary);
-  --sidebar-primary-foreground: oklch(0.12 0 0);
-  --sidebar-accent: oklch(0.92 0.03 70);
+  --sidebar-primary-foreground: var(--primary-foreground);
+  --sidebar-accent: oklch(0.95 0.005 255);
   --sidebar-accent-foreground: var(--foreground);
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
 }
 
 .dark {
-  --background: oklch(0.12 0 0);
-  --foreground: oklch(0.98 0 0);
-  --card: oklch(0.18 0 0);
-  --card-foreground: oklch(0.98 0 0);
-  --popover: oklch(0.18 0 0);
-  --popover-foreground: oklch(0.98 0 0);
-  --primary: oklch(0.68 0.19 45);
-  --primary-foreground: oklch(0.12 0 0);
-  --secondary: oklch(0.25 0 0);
-  --secondary-foreground: oklch(0.98 0 0);
-  --muted: oklch(0.25 0 0);
-  --muted-foreground: oklch(0.65 0 0);
-  --accent: oklch(0.68 0.19 45);
-  --accent-foreground: oklch(0.12 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.98 0 0);
-  --border: oklch(0.25 0 0);
-  --input: oklch(0.25 0 0);
-  --ring: oklch(0.68 0.19 45);
-  --chart-1: oklch(0.68 0.19 45);
-  --chart-2: oklch(0.75 0.15 85);
-  --chart-3: oklch(0.55 0.12 25);
-  --chart-4: oklch(0.82 0.1 95);
-  --chart-5: oklch(0.45 0.08 15);
-  --sidebar: oklch(0.18 0 0);
-  --sidebar-foreground: oklch(0.98 0 0);
-  --sidebar-primary: oklch(0.68 0.19 45);
-  --sidebar-primary-foreground: oklch(0.12 0 0);
-  --sidebar-accent: oklch(0.25 0 0);
-  --sidebar-accent-foreground: oklch(0.98 0 0);
-  --sidebar-border: oklch(0.25 0 0);
-  --sidebar-ring: oklch(0.68 0.19 45);
+  --background: oklch(0.12 0.02 255);
+  --foreground: oklch(0.96 0.01 255);
+  --card: oklch(0.16 0.015 255);
+  --card-foreground: oklch(0.97 0.01 255);
+  --popover: oklch(0.14 0.015 255);
+  --popover-foreground: oklch(0.97 0.01 255);
+  --primary: oklch(0.82 0.01 255);
+  --primary-foreground: oklch(0.17 0.02 255);
+  --secondary: oklch(0.21 0.006 255);
+  --secondary-foreground: oklch(0.88 0.01 255);
+  --muted: oklch(0.2 0.006 255);
+  --muted-foreground: oklch(0.67 0.01 255);
+  --accent: oklch(0.63 0.07 230);
+  --accent-foreground: oklch(0.15 0.02 255);
+  --destructive: oklch(0.48 0.16 27);
+  --destructive-foreground: oklch(0.96 0.01 255);
+  --border: oklch(0.26 0.005 255);
+  --input: oklch(0.26 0.005 255);
+  --ring: var(--accent);
+  --chart-1: oklch(0.7 0.09 231);
+  --chart-2: oklch(0.62 0.07 210);
+  --chart-3: oklch(0.68 0.06 175);
+  --chart-4: oklch(0.58 0.05 260);
+  --chart-5: oklch(0.72 0.06 120);
+  --sidebar: oklch(0.15 0.01 255);
+  --sidebar-foreground: oklch(0.92 0.01 255);
+  --sidebar-primary: oklch(0.82 0.01 255);
+  --sidebar-primary-foreground: oklch(0.17 0.02 255);
+  --sidebar-accent: oklch(0.21 0.006 255);
+  --sidebar-accent-foreground: oklch(0.88 0.01 255);
+  --sidebar-border: oklch(0.26 0.005 255);
+  --sidebar-ring: var(--ring);
 }
 
 @theme inline {
@@ -124,20 +124,7 @@
   }
 }
 
-/* Halloween neon treatments */
-@keyframes neon-glow {
-  0%,
-  100% {
-    background-position: 0% 50%;
-    filter: drop-shadow(0 0 20px rgba(249, 115, 22, 0.6)) drop-shadow(0 0 40px rgba(249, 115, 22, 0.4));
-  }
-  50% {
-    background-position: 100% 50%;
-    filter: drop-shadow(0 0 30px rgba(249, 115, 22, 0.8)) drop-shadow(0 0 60px rgba(249, 115, 22, 0.5))
-      drop-shadow(0 0 80px rgba(168, 85, 247, 0.3));
-  }
-}
-
+/* Cal.com inspired motion treatments */
 @keyframes gradient-flow {
   0% {
     background-position: 0% 50%;
@@ -147,22 +134,5 @@
   }
   100% {
     background-position: 0% 50%;
-  }
-}
-
-/* Candlelight flicker for seasonal flair */
-@keyframes candle-flicker {
-  0%,
-  100% {
-    filter: drop-shadow(0 0 8px rgba(249, 115, 22, 0.6));
-  }
-  25% {
-    filter: drop-shadow(0 0 12px rgba(249, 115, 22, 0.8));
-  }
-  50% {
-    filter: drop-shadow(0 0 6px rgba(249, 115, 22, 0.5));
-  }
-  75% {
-    filter: drop-shadow(0 0 10px rgba(249, 115, 22, 0.7));
   }
 }

--- a/modules/dashboard/App.tsx
+++ b/modules/dashboard/App.tsx
@@ -36,9 +36,9 @@ export const App: FC<DashboardAppProps> = ({ initialMeetings }) => {
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-background text-foreground transition-colors duration-300">
-      <div className="pointer-events-none absolute -top-32 left-1/2 h-[480px] w-[480px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(249,115,22,0.28),_transparent_70%)] blur-3xl" />
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,_rgba(168,85,247,0.25),_transparent_55%)]" />
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_80%_30%,_rgba(59,130,246,0.18),_transparent_60%)] mix-blend-screen" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-[520px] bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.16),_transparent_65%)] dark:bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.2),_transparent_70%)]" />
+      <div className="pointer-events-none absolute right-[-18%] top-32 h-[420px] w-[420px] rounded-full bg-[conic-gradient(from_140deg,_rgba(14,165,233,0.28),_transparent_55%)] blur-3xl" />
+      <div className="pointer-events-none absolute left-[-12%] bottom-[-20%] h-[360px] w-[360px] rounded-full bg-[radial-gradient(circle_at_bottom,_rgba(12,74,110,0.18),_transparent_60%)] blur-3xl" />
       <div className="relative mx-auto max-w-7xl px-4 py-10 sm:pt-16">
         <motion.div
           variants={fadeInFromTop}
@@ -47,17 +47,15 @@ export const App: FC<DashboardAppProps> = ({ initialMeetings }) => {
           transition={createTransition()}
           className="mb-10 max-w-3xl text-center sm:text-left"
         >
-          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-4 py-1 text-xs font-medium text-primary shadow-[0_0_20px_rgba(249,115,22,0.35)] animate-[gradient-flow_5s_ease_infinite]">
-            <span className="text-base animate-[float_3s_ease-in-out_infinite]">🕸️</span>
-            Insights in full moon mode
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-border/70 bg-secondary/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+            <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+            Cal.com overview
           </div>
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
-            <span className="bg-gradient-to-r from-primary via-orange-500 to-primary bg-clip-text text-transparent [text-shadow:0_0_30px_rgba(249,115,22,0.45)]">
-              Meeting Insights
-            </span>
+          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+            Meeting intelligence that mirrors Cal.com
           </h1>
-          <p className="mt-2 text-sm text-muted-foreground sm:text-base">
-            Comprehensive analytics for your calendar data with a seasonal glow.
+          <p className="mt-3 text-sm text-muted-foreground sm:text-base">
+            Focus your operations reviews on signal, not noise. Surface booking momentum, host load, and event type velocity in a presentation layer that feels native to Cal.com.
           </p>
         </motion.div>
 

--- a/modules/landing/Hero.tsx
+++ b/modules/landing/Hero.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import { authClient } from "@/lib/auth-client"
 import { signIn } from "@/lib/auth/sign-in"
 import Link from "next/link"
-import Image from "next/image"
 import { useState } from "react"
 import { toast } from "sonner"
 
@@ -33,109 +32,115 @@ export function Hero() {
   const showConnectCta = !session || isPending || !!error
 
   return (
-    <section className="relative overflow-hidden border-b border-border">
-      <div className="absolute inset-0 bg-gradient-to-t from-background via-transparent to-transparent" />
+    <section className="relative overflow-hidden border-b border-border bg-background">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-0 h-[540px] bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.14),_transparent_65%)] dark:bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.2),_transparent_70%)]" />
+        <div className="absolute left-1/2 top-1/2 h-64 w-64 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[conic-gradient(from_120deg,_rgba(14,165,233,0.3),_transparent_55%)] blur-3xl" />
+      </div>
 
       <div className="container relative mx-auto px-4 py-24 md:py-32">
-        <div className="mx-auto max-w-4xl text-center">
-          <div className="mb-8 flex items-center justify-center">
-            <h2 className="relative font-serif text-6xl font-bold tracking-wider md:text-8xl">
-              <span className="bg-gradient-to-r from-primary via-orange-600 to-primary bg-clip-text text-transparent [text-shadow:0_0_30px_rgba(249,115,22,0.5)]">
-                Cal
-              </span>
-              <span className="text-foreground">lytics</span>
-              <span className="absolute -right-8 -bottom-4 text-4xl md:-right-12 md:-bottom-6 md:text-6xl animate-[candle-flicker_3s_ease-in-out_infinite]">
-                🎃
-              </span>
-              <span className="absolute -left-6 top-0 text-2xl md:-left-10 md:text-4xl animate-bounce [animation-duration:2s]">
-                🦇
-              </span>
-            </h2>
-          </div>
+        <div className="grid items-center gap-16 lg:grid-cols-[3fr_2fr]">
+          <div className="text-center lg:text-left">
+            <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-secondary/60 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground lg:mx-0">
+              <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+              Cal.com native analytics
+            </div>
+            <h1 className="text-balance font-sans text-4xl font-semibold tracking-tight text-foreground sm:text-5xl md:text-6xl">
+              Operational clarity for every Cal.com booking
+            </h1>
+            <p className="mt-6 text-pretty text-base leading-relaxed text-muted-foreground md:text-lg">
+              Streamline scheduling performance reviews with an opinionated dashboard that mirrors Cal.com&apos;s product language. Monitor pipeline health, surface revenue signals, and confidently communicate growth to stakeholders.
+            </p>
 
-          <div className="mb-6 inline-block rounded-full border border-primary/20 bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary shadow-[0_0_20px_rgba(249,115,22,0.3)] animate-[gradient-flow_4s_ease_infinite]">
-            <span className="flex items-center gap-2">
-              <span className="text-base animate-[float_3s_ease-in-out_infinite]">👻</span>
-              Now Live on Halloween
-            </span>
-          </div>
-
-          <h1 className="mb-6 text-balance font-sans text-5xl font-bold leading-tight tracking-tight text-foreground md:text-7xl">
-            Analytics for{" "}
-            <span className="relative inline-flex h-10 w-24 rotate-[-3deg] shrink-0 items-center justify-center md:h-16 md:w-32">
-              <Image
-                src="/platforms/cal-logo-light.jpeg"
-                alt="Cal.com"
-                fill
-                sizes="(min-width: 768px) 8rem, 6rem"
-                className="object-cover dark:hidden"
-                priority
-              />
-              <Image
-                src="/platforms/cal-logo-dark.jpeg"
-                alt="Cal.com"
-                fill
-                sizes="(min-width: 768px) 8rem, 6rem"
-                className="hidden object-cover dark:block"
-                priority
-              />
-            </span>{" "}
-            simplified
-          </h1>
-
-          <p className="mb-10 text-pretty text-lg leading-relaxed text-muted-foreground md:text-xl">
-            Launching this Halloween with powerful insights for your{" "}
-            <span className="bg-gradient-to-r from-primary via-orange-600 to-primary bg-clip-text font-semibold text-transparent">
-              Cal.com
-            </span>{" "}
-            bookings. Track meetings, analyze conversion rates, and optimize your scheduling workflow with spooky precision.
-          </p>
-
-          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-            {showConnectCta ? (
-              <>
+            <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:justify-start">
+              {showConnectCta ? (
+                <>
+                  <Button
+                    size="lg"
+                    className="min-w-[200px] text-base font-semibold"
+                    disabled={isConnecting}
+                    onClick={handleCalOAuth}
+                  >
+                    {isConnecting ? "Connecting..." : "Connect with Cal.com"}
+                  </Button>
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="min-w-[200px] text-base border-border/70 bg-transparent text-foreground transition-colors hover:bg-secondary/50"
+                    asChild
+                  >
+                    <Link href="/demo">View Demo</Link>
+                  </Button>
+                </>
+              ) : (
                 <Button
                   size="lg"
-                  className="min-w-[200px] text-base font-semibold hover:cursor-pointer"
-                  disabled={isConnecting}
-                  onClick={handleCalOAuth}
+                  variant="outline"
+                  className="min-w-[200px] text-base border-primary/50 bg-primary/5 text-primary transition-transform hover:-translate-y-0.5 hover:border-primary/70 hover:bg-primary/15 hover:text-foreground"
+                  asChild
                 >
-                  {isConnecting ? "Connecting..." : "Connect with Cal.com"}
+                  <Link href="/dashboard">Go to Dashboard</Link>
                 </Button>
-                <Button size="lg" variant="outline" className="min-w-[200px] text-base bg-transparent" asChild>
-                  <Link href="/demo">View Demo</Link>
-                </Button>
-              </>
-            ) : (
-              <Button
-                size="lg"
-                variant="outline"
-                className="min-w-[200px] text-base border-primary/50 bg-primary/5 text-primary transition-transform hover:-translate-y-0.5 hover:border-primary/70 hover:bg-primary/25 hover:text-foreground"
-                asChild
-              >
-                <Link href="/dashboard">Go to Dashboard</Link>
-              </Button>
-            )}
+              )}
+            </div>
+
+            <ul className="mt-10 flex flex-col items-center gap-4 text-sm text-muted-foreground sm:flex-row sm:items-start sm:text-left">
+              <li className="flex items-center gap-2">
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-secondary text-xs font-semibold text-foreground">
+                  •
+                </span>
+                OAuth-secured Cal.com access
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-secondary text-xs font-semibold text-foreground">
+                  •
+                </span>
+                Ready for revenue and ops reviews
+              </li>
+              <li className="flex items-center gap-2">
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-secondary text-xs font-semibold text-foreground">
+                  •
+                </span>
+                Exportable KPIs on demand
+              </li>
+            </ul>
           </div>
 
-          <div className="mt-12 flex items-center justify-center gap-8 text-sm text-muted-foreground">
-            <div className="flex items-center gap-2">
-              <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-              <span>No credit card required</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              <span>Launching Oct 31st</span>
-            </div>
+          <div className="mx-auto w-full max-w-md rounded-3xl border border-border/70 bg-card/70 p-8 text-left shadow-lg backdrop-blur">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">Snapshot</p>
+            <dl className="mt-6 grid grid-cols-2 gap-6">
+              <div>
+                <dt className="text-xs uppercase tracking-[0.18em] text-muted-foreground">7 day bookings</dt>
+                <dd className="mt-2 text-3xl font-semibold text-foreground">284</dd>
+                <dd className="text-xs font-medium text-accent">+18.4% vs last week</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Avg. conversion</dt>
+                <dd className="mt-2 text-3xl font-semibold text-foreground">42%</dd>
+                <dd className="text-xs font-medium text-muted-foreground">Across 6 event types</dd>
+              </div>
+              <div className="col-span-2">
+                <dt className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Host coverage</dt>
+                <dd className="mt-3 flex items-baseline gap-3 text-2xl font-semibold text-foreground">
+                  11 hosts active
+                  <span className="rounded-full bg-secondary px-2 py-1 text-xs font-medium text-foreground">98% SLA</span>
+                </dd>
+              </div>
+              <div className="col-span-2">
+                <dt className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Booking velocity</dt>
+                <dd className="mt-3 flex items-end gap-3">
+                  <div className="flex flex-1 items-end gap-1">
+                    <span className="h-6 w-2 rounded-full bg-accent/60" />
+                    <span className="h-8 w-2 rounded-full bg-accent/70" />
+                    <span className="h-10 w-2 rounded-full bg-accent" />
+                    <span className="h-7 w-2 rounded-full bg-accent/70" />
+                    <span className="h-9 w-2 rounded-full bg-accent/80" />
+                    <span className="h-11 w-2 rounded-full bg-accent" />
+                  </div>
+                  <span className="text-sm font-medium text-muted-foreground">Weekly trend</span>
+                </dd>
+              </div>
+            </dl>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- retune global design tokens to a Cal.com-native neutral palette with refreshed accent/ring colors
- reimagine the landing hero with brand-aligned badge, copy, and analytics snapshot card
- polish the dashboard shell overlays and intro copy to match the updated visual language

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69067805c048832c9cb3bcd8834bebed